### PR TITLE
Update mxnet to get advantage of OneDNN Intel acceleration

### DIFF
--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,2 +1,3 @@
+mxnet==1.7.0
 gluonts==0.6.4
 dill==0.3.3

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,3 +1,3 @@
-mxnet==1.7.0
+mxnet==1.7.0.post1
 gluonts==0.6.4
 dill==0.3.3

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,3 +1,2 @@
-mxnet==1.6.0
-gluonts==0.6.2
-dill==0.3.2
+gluonts==0.6.4
+dill==0.3.3


### PR DESCRIPTION
This works out of the box on mxnet 1.7. I verified it on dku34 with
```
import mxnet.runtime
fs=mxnet.runtime.Features()
fs.is_enabled('MKLDNN')
```

We should verify that it decreases runtime in our benchmarks