### PR TITLE
Feature/timestamps preparation

### DIFF
--- a/custom-recipes/timeseries-forecast-1-train-evaluate/recipe.json
+++ b/custom-recipes/timeseries-forecast-1-train-evaluate/recipe.json
@@ -102,11 +102,107 @@
                     "label": "Semester"
                 },
                 {
-                    "value": "Y",
+                    "value": "A",
                     "label": "Year"
                 }
             ],
             "defaultValue": "D"
+        },
+        {
+            "name": "frequency_end_of_year",
+            "label": "End of year month",
+            "type": "SELECT",
+            "mandatory": false,
+            "defaultValue": "DEC",
+            "visibilityCondition": "model.frequency_unit == 'A'",
+            "selectChoices": [
+                {
+                    "value": "JAN",
+                    "label": "January"
+                },
+                {
+                    "value": "FEB",
+                    "label": "February"
+                },
+                {
+                    "value": "MAR",
+                    "label": "March"
+                },
+                {
+                    "value": "APR",
+                    "label": "April"
+                },
+                {
+                    "value": "MAY",
+                    "label": "May"
+                },
+                {
+                    "value": "JUN",
+                    "label": "June"
+                },
+                {
+                    "value": "JUL",
+                    "label": "July"
+                },
+                {
+                    "value": "AUG",
+                    "label": "August"
+                },
+                {
+                    "value": "SEP",
+                    "label": "September"
+                },
+                {
+                    "value": "OCT",
+                    "label": "October"
+                },
+                {
+                    "value": "NOV",
+                    "label": "November"
+                },
+                {
+                    "value": "DEC",
+                    "label": "December"
+                }
+            ]
+        },
+        {
+            "name": "frequency_end_of_week",
+            "label": "End of week day",
+            "type": "SELECT",
+            "mandatory": false,
+            "defaultValue": "SUN",
+            "visibilityCondition": "model.frequency_unit == 'W'",
+            "selectChoices": [
+                {
+                    "value": "SUN",
+                    "label": "Sunday"
+                },
+                {
+                    "value": "MON",
+                    "label": "Monday"
+                },
+                {
+                    "value": "TUE",
+                    "label": "Tuesday"
+                },
+                {
+                    "value": "WED",
+                    "label": "Wednesday"
+                },
+                {
+                    "value": "THU",
+                    "label": "Thursday"
+                },
+                {
+                    "value": "FRI",
+                    "label": "Friday"
+                },
+                {
+                    "value": "SAT",
+                    "label": "Saturday"
+                }
+            ]
         },
         {
             "name": "frequency_step_hours",
@@ -459,7 +555,7 @@
             "defaultValue": 10000,
             "mandatory": false,
             "minI": 1,
-            "visibilityCondition": "model.sampling_method==last_records"
+            "visibilityCondition": "model.sampling_method=='last_records'"
         },
         {
             "name": "evaluation_strategy",

--- a/custom-recipes/timeseries-forecast-1-train-evaluate/recipe.json
+++ b/custom-recipes/timeseries-forecast-1-train-evaluate/recipe.json
@@ -434,6 +434,34 @@
             "type": "SEPARATOR"
         },
         {
+            "name": "sampling_method",
+            "label": "Sampling method",
+            "type": "SELECT",
+            "mandatory": true,
+            "description": "",
+            "selectChoices": [
+                {
+                    "value": "last_records",
+                    "label": "Last records (most recent)"
+                },
+                {
+                    "value": "no_sampling",
+                    "label": "No sampling (whole data)"
+                }
+            ],
+            "defaultValue": "last_records"
+        },
+        {
+            "name": "number_records",
+            "label": "Nb. records",
+            "description": "Number of records to use per timeseries",
+            "type": "INT",
+            "defaultValue": 10000,
+            "mandatory": false,
+            "minI": 1,
+            "visibilityCondition": "model.sampling_method==last_records"
+        },
+        {
             "name": "evaluation_strategy",
             "label": "Splitting strategy",
             "type": "SELECT",

--- a/custom-recipes/timeseries-forecast-1-train-evaluate/recipe.py
+++ b/custom-recipes/timeseries-forecast-1-train-evaluate/recipe.py
@@ -7,6 +7,7 @@ from dku_io_utils.recipe_config_loading import load_training_config, get_models_
 from dku_io_utils.utils import write_to_folder
 from constants import EVALUATION_METRICS_DESCRIPTIONS, METRICS_COLUMNS_DESCRIPTIONS
 from gluonts_forecasts.model_handler import get_model_label
+from gluonts_forecasts.timeseries_preparation import prepare_timeseries_dataframe
 from safe_logger import SafeLogger
 from time import perf_counter
 
@@ -21,6 +22,14 @@ logger.info("Starting training session {}...".format(session_name))
 
 training_df = params["training_dataset"].get_dataframe()
 
+training_df_prepared = prepare_timeseries_dataframe(
+    training_df,
+    time_column_name=params["time_column_name"],
+    frequency=params["frequency"],
+    timeseries_identifiers_names=params["timeseries_identifiers_names"],
+    max_timeseries_length=params["max_timeseries_length"],
+)
+
 training_session = TrainingSession(
     target_columns_names=params["target_columns_names"],
     time_column_name=params["time_column_name"],
@@ -28,7 +37,7 @@ training_session = TrainingSession(
     epoch=params["epoch"],
     models_parameters=models_parameters,
     prediction_length=params["prediction_length"],
-    training_df=training_df,
+    training_df=training_df_prepared,
     make_forecasts=params["make_forecasts"],
     external_features_columns_names=params["external_features_columns_names"],
     timeseries_identifiers_names=params["timeseries_identifiers_names"],

--- a/python-lib/dku_io_utils/recipe_config_loading.py
+++ b/python-lib/dku_io_utils/recipe_config_loading.py
@@ -118,6 +118,13 @@ def load_training_config(recipe_config):
         params["batch_size"] = 32
         params["num_batches_per_epoch"] = -1
 
+    params["sampling_method"] = recipe_config.get("sampling_method", "last_records")
+    params["max_timeseries_length"] = None
+    if params["sampling_method"] == "last_records":
+        params["max_timeseries_length"] = recipe_config.get("number_records", 10000)
+        if params["max_timeseries_length"] < 1:
+            raise PluginParamValidationError("Number of records must be higher than 1")
+
     params["gpu"] = recipe_config.get("gpu", "no_gpu")
     params["evaluation_strategy"] = "split"
     params["evaluation_only"] = False

--- a/python-lib/gluonts_forecasts/gluon_dataset.py
+++ b/python-lib/gluonts_forecasts/gluon_dataset.py
@@ -1,4 +1,3 @@
-from gluonts_forecasts.utils import assert_time_column_valid
 from gluonts.dataset.common import ListDataset
 from constants import TIMESERIES_KEYS
 
@@ -16,6 +15,7 @@ class GluonDataset:
         timeseries_identifiers_names (list): Columns to identify multiple time series when data is in long format
         external_features_columns_names (list): List of columns with dynamic real features over time
     """
+
     def __init__(
         self,
         dataframe,
@@ -24,9 +24,9 @@ class GluonDataset:
         target_columns_names,
         timeseries_identifiers_names=None,
         external_features_columns_names=None,
-        min_length=None
+        min_length=None,
     ):
-        self.dataframe = dataframe.sort_values(by=time_column_name, ascending=True)
+        self.dataframe = dataframe  # .sort_values(by=time_column_name, ascending=True)
         self.time_column_name = time_column_name
         self.frequency = frequency
         self.target_columns_names = target_columns_names
@@ -47,22 +47,19 @@ class GluonDataset:
         multivariate_timeseries_per_cut_length = [[] for cut_length in cut_lengths]
         if self.timeseries_identifiers_names:
             for identifiers_values, identifiers_df in self.dataframe.groupby(self.timeseries_identifiers_names):
-                assert_time_column_valid(
-                    identifiers_df,
-                    self.time_column_name,
-                    self.frequency
-                )
+                # assert_time_column_valid(identifiers_df, self.time_column_name, self.frequency)
                 for cut_length_index, cut_length in enumerate(cut_lengths):
-                    multivariate_timeseries_per_cut_length[cut_length_index] += self._create_gluon_multivariate_timeseries(identifiers_df, cut_length, identifiers_values=identifiers_values)
+                    multivariate_timeseries_per_cut_length[cut_length_index] += self._create_gluon_multivariate_timeseries(
+                        identifiers_df, cut_length, identifiers_values=identifiers_values
+                    )
         else:
-            assert_time_column_valid(self.dataframe, self.time_column_name, self.frequency)
+            # assert_time_column_valid(self.dataframe, self.time_column_name, self.frequency)
             for cut_length_index, cut_length in enumerate(cut_lengths):
                 multivariate_timeseries_per_cut_length[cut_length_index] += self._create_gluon_multivariate_timeseries(self.dataframe, cut_length)
         gluon_list_dataset_per_cut_length = []
         for multivariate_timeseries in multivariate_timeseries_per_cut_length:
             gluon_list_dataset_per_cut_length += [ListDataset(multivariate_timeseries, freq=self.frequency)]
         return gluon_list_dataset_per_cut_length
-
 
     def _create_gluon_multivariate_timeseries(self, dataframe, cut_length, identifiers_values=None):
         """Create a list of timeseries dictionaries for each target column

--- a/python-lib/gluonts_forecasts/gluon_dataset.py
+++ b/python-lib/gluonts_forecasts/gluon_dataset.py
@@ -26,7 +26,7 @@ class GluonDataset:
         external_features_columns_names=None,
         min_length=None,
     ):
-        self.dataframe = dataframe  # .sort_values(by=time_column_name, ascending=True)
+        self.dataframe = dataframe
         self.time_column_name = time_column_name
         self.frequency = frequency
         self.target_columns_names = target_columns_names
@@ -47,13 +47,11 @@ class GluonDataset:
         multivariate_timeseries_per_cut_length = [[] for cut_length in cut_lengths]
         if self.timeseries_identifiers_names:
             for identifiers_values, identifiers_df in self.dataframe.groupby(self.timeseries_identifiers_names):
-                # assert_time_column_valid(identifiers_df, self.time_column_name, self.frequency)
                 for cut_length_index, cut_length in enumerate(cut_lengths):
                     multivariate_timeseries_per_cut_length[cut_length_index] += self._create_gluon_multivariate_timeseries(
                         identifiers_df, cut_length, identifiers_values=identifiers_values
                     )
         else:
-            # assert_time_column_valid(self.dataframe, self.time_column_name, self.frequency)
             for cut_length_index, cut_length in enumerate(cut_lengths):
                 multivariate_timeseries_per_cut_length[cut_length_index] += self._create_gluon_multivariate_timeseries(self.dataframe, cut_length)
         gluon_list_dataset_per_cut_length = []

--- a/python-lib/gluonts_forecasts/model.py
+++ b/python-lib/gluonts_forecasts/model.py
@@ -230,6 +230,7 @@ class Model(ModelHandler):
         mean_forecasts_timeseries = {}
         for i, sample_forecasts in enumerate(forecasts_list):
             series = sample_forecasts.quantile_ts(0.5).rename(f"{self.model_name}_{train_list_dataset.list_data[i][TIMESERIES_KEYS.TARGET_NAME]}")
+            print(f"series: {series}")
             if TIMESERIES_KEYS.IDENTIFIERS in train_list_dataset.list_data[i]:
                 timeseries_identifier_key = tuple(sorted(train_list_dataset.list_data[i][TIMESERIES_KEYS.IDENTIFIERS].items()))
             else:

--- a/python-lib/gluonts_forecasts/model.py
+++ b/python-lib/gluonts_forecasts/model.py
@@ -230,7 +230,6 @@ class Model(ModelHandler):
         mean_forecasts_timeseries = {}
         for i, sample_forecasts in enumerate(forecasts_list):
             series = sample_forecasts.quantile_ts(0.5).rename(f"{self.model_name}_{train_list_dataset.list_data[i][TIMESERIES_KEYS.TARGET_NAME]}")
-            print(f"series: {series}")
             if TIMESERIES_KEYS.IDENTIFIERS in train_list_dataset.list_data[i]:
                 timeseries_identifier_key = tuple(sorted(train_list_dataset.list_data[i][TIMESERIES_KEYS.IDENTIFIERS].items()))
             else:

--- a/python-lib/gluonts_forecasts/timeseries_preparation.py
+++ b/python-lib/gluonts_forecasts/timeseries_preparation.py
@@ -61,6 +61,8 @@ class TimeseriesPreparator:
         Check there are no duplicate timestamps.
 
         Examples:
+            '2020-12-15 12:45:30' becomes '2020-12-15 12:40:00' with frequency '20min'
+            '2020-12-15 12:00:00' becomes '2020-12-15 00:00:00' with frequency '24H'
             '2020-12-15 12:30:00' becomes '2020-12-15 00:00:00' with frequency 'D'
             '2020-12-15 12:30:00' becomes '2020-12-31 00:00:00' with frequency 'M'
             '2020-12-15 12:30:00' becomes '2021-01-30 00:00:00' with frequency 'A-JAN'

--- a/python-lib/gluonts_forecasts/timeseries_preparation.py
+++ b/python-lib/gluonts_forecasts/timeseries_preparation.py
@@ -1,0 +1,168 @@
+import pandas as pd
+import numpy as np
+from pandas.api.types import is_numeric_dtype, is_string_dtype
+from pandas.tseries.offsets import Tick, BusinessDay, Week, MonthEnd, YearEnd
+from pandas.tseries.frequencies import to_offset
+import re
+
+
+def prepare_timeseries_dataframe(dataframe, time_column_name, frequency, timeseries_identifiers_names=[], max_timeseries_length=None):
+    """Convert time column to pandas.Datetime without timezones. Truncate timestamps to selected frequency.
+    Check that there are no duplicate timestamps and that there are no missing timestamps.
+    Sort timeseries. Keep only the most recent timestamps of each timeseries if specified.
+
+    Args:
+        dataframe (DataFrame)
+        time_column_name (str)
+        frequency (str)
+        timeseries_identifiers_names (list, optional): List of timeseries identifiers columns. Defaults to [].
+        max_timeseries_length (int, optional): Maximum number of timestamps to keep per timeseries. Defaults to None.
+
+    Raises:
+        ValueError: If the time column cannot be parsed as a date by pandas.
+
+    Returns:
+        Prepared timeseries
+    """
+    try:
+        dataframe[time_column_name] = pd.to_datetime(dataframe[time_column_name]).dt.tz_localize(tz=None)
+    except Exception:
+        raise ValueError(f"Please parse the date column '{time_column_name}' in a Prepare recipe")
+
+    preparator = TimeseriesPreparator(time_column_name, frequency, timeseries_identifiers_names)
+
+    dataframe_prepared = dataframe.copy()
+
+    preparator.check_data_types(dataframe_prepared)
+
+    dataframe_prepared = preparator.truncate_timestamps(dataframe_prepared)
+
+    dataframe_prepared = preparator.sort(dataframe_prepared)
+
+    preparator.check_regular_frequency(dataframe_prepared)
+
+    if max_timeseries_length:
+        dataframe_prepared = preparator.keep_last_timestamps(dataframe_prepared, max_timeseries_length)
+
+    return dataframe_prepared
+
+
+class TimeseriesPreparator:
+    def __init__(self, time_column_name, frequency, timeseries_identifiers_names):
+        self.time_column_name = time_column_name
+        self.frequency = frequency
+        self.timeseries_identifiers_names = timeseries_identifiers_names
+
+    def check_data_types(self, df):
+        self._check_timeseries_identifiers_columns_types(df)
+
+    def truncate_timestamps(self, df):
+        """Truncate timestamps to selected frequency. For Week/Month/Year, truncate to end of Week/Month/Year.
+        Check there are no duplicate timestamps.
+
+        Examples:
+            '2020-12-15 12:30:00' becomes '2020-12-15 00:00:00' with frequency 'D'
+            '2020-12-15 12:30:00' becomes '2020-12-31 00:00:00' with frequency 'M'
+            '2020-12-15 12:30:00' becomes '2021-01-30 00:00:00' with frequency 'A-JAN'
+
+        Args:
+            df (DataFrame): Dataframe in wide or long format with a time column.
+
+        Raises:
+            ValueError: If there are duplicates timestamps before or after truncation.
+
+        Returns:
+            Sorted DataFrame with truncated timestamps.
+        """
+        df_truncated = df.copy()
+
+        if self._has_duplicates_timestamps(df_truncated):
+            error_message = "Input dataset has duplicate timestamps."
+            if len(self.timeseries_identifiers_names) == 0:
+                error_message += " If the input dataset is in long format, make sure to specify it."
+            raise ValueError(error_message)
+
+        frequency_offset = to_offset(self.frequency)
+        if isinstance(frequency_offset, Tick):
+            df_truncated[self.time_column_name] = df_truncated[self.time_column_name].dt.floor(self.frequency)
+        elif isinstance(frequency_offset, BusinessDay):
+            df_truncated[self.time_column_name] = df_truncated[self.time_column_name].dt.floor("D")
+        else:
+            if isinstance(frequency_offset, Week):
+                truncation_offset = pd.offsets.Week(weekday=frequency_offset.weekday, n=0)
+            elif isinstance(frequency_offset, MonthEnd):
+                truncation_offset = pd.offsets.MonthEnd(n=0)
+            elif isinstance(frequency_offset, YearEnd):
+                truncation_offset = pd.offsets.YearEnd(month=frequency_offset.month, n=0)
+
+            df_truncated[self.time_column_name] = df_truncated[self.time_column_name].dt.floor("D") + truncation_offset
+
+        if self._has_duplicates_timestamps(df_truncated):
+            raise ValueError("Input dataset has duplicate timestamps after truncation to selected frequency")
+
+        return df_truncated
+
+    def sort(self, df):
+        """Return a DataFrame sorted by timeseries identifiers and time column (both ascending) """
+        return df.sort_values(by=self.timeseries_identifiers_names + [self.time_column_name])
+
+    def check_regular_frequency(self, df):
+        """Check that time column exactly equals the pandas.dat_range with selected frequency """
+        if self.timeseries_identifiers_names:
+            for identifiers_values, identifiers_df in df.groupby(self.timeseries_identifiers_names):
+                assert_time_column_valid(identifiers_df, self.time_column_name, self.frequency)
+        else:
+            assert_time_column_valid(df, self.time_column_name, self.frequency)
+
+    def keep_last_timestamps(self, df, max_timeseries_length):
+        """Keep only at most the last max_timeseries_length timestamps of each timeseries.
+
+        Args:
+            df (DataFrame)
+            max_timeseries_length (int): Maximum number of timestamps to keep per timeseries.
+
+        Returns:
+            Filtered dataframe
+        """
+        if len(self.timeseries_identifiers_names) == 0:
+            return df.tail(max_timeseries_length)
+        else:
+            return df.groupby(self.timeseries_identifiers_names).apply(lambda x: x.tail(max_timeseries_length)).reset_index(drop=True)
+
+    def _has_duplicates_timestamps(self, df):
+        """Return True if there are no duplicate timestamps within each timeseries """
+        return any(df.duplicated(subset=self.timeseries_identifiers_names + [self.time_column_name], keep=False))
+
+    def _check_timeseries_identifiers_columns_types(self, df):
+        """ Raises ValueError if a timeseries identifiers column is not numerical or string """
+        for column_name in self.timeseries_identifiers_names:
+            if not is_numeric_dtype(df[column_name]) and not is_string_dtype(df[column_name]):
+                raise ValueError(f"Time series identifier '{column_name}' must be of string or numeric type")
+
+
+def assert_time_column_valid(dataframe, time_column_name, frequency, start_date=None, periods=None):
+    """Assert that the time column has the same values as the pandas.date_range generated with frequency and the first and last row of dataframe[time_column_name]
+    (or with start_date and periods if specified).
+
+    Args:
+        dataframe (DataFrame)
+        time_column_name (str)
+        frequency (str): Use as frequency of pandas.date_range.
+        start_date (pandas.Timestamp, optional): Use as start_date of pandas.date_range if specified. Defaults to None.
+        periods (int, optional): Use as periods of pandas.date_range if specified. Defaults to None.
+
+    Raises:
+        ValueError: If the time column doesn't have regular time intervals of the chosen frequency.
+    """
+    if start_date is None:
+        start_date = dataframe[time_column_name].iloc[0]
+    if periods:
+        date_range_values = pd.date_range(start=start_date, periods=periods, freq=frequency).values
+    else:
+        end_date = dataframe[time_column_name].iloc[-1]
+        date_range_values = pd.date_range(start=start_date, end=end_date, freq=frequency).values
+
+    if not np.array_equal(dataframe[time_column_name].values, date_range_values):
+        error_message = f"Time column '{time_column_name}' has missing values with frequency '{frequency}'."
+        error_message += " You can use the Time Series Preparation plugin to resample your time column."
+        raise ValueError(error_message)

--- a/python-lib/gluonts_forecasts/training_session.py
+++ b/python-lib/gluonts_forecasts/training_session.py
@@ -74,27 +74,17 @@ class TrainingSession:
         self.context_length = context_length
 
     def init(self, session_name, partition_root=None):
-        """Create the session_path. Convert time column to pandas.Datetime without timezones.
-        Check types of target, external features and timeseries identifiers columns.
+        """Create the session_path. Check types of target, external features and timeseries identifiers columns.
 
         Args:
             session_name (Timestamp)
             partition_root (str, optional): Partition root path, concatenated to session_name to create the session_path. Defaults to None.
-
-        Raises:
-            ValueError: If the time column cannot be parsed as a date by pandas.
         """
         self.session_name = session_name
         if partition_root is None:
             self.session_path = session_name
         else:
             self.session_path = os.path.join(partition_root, session_name)
-        try:
-            self.training_df[self.time_column_name] = pd.to_datetime(
-                self.training_df[self.time_column_name]
-            ).dt.tz_localize(tz=None)
-        except Exception:
-            raise ValueError(f"Please parse the date column '{self.time_column_name}' in a Prepare recipe")
 
         self._check_target_columns_types()
         self._check_external_features_columns_types()
@@ -161,9 +151,7 @@ class TrainingSession:
         """Evaluate all the selected models and get the metrics dataframe. """
         metrics_df = pd.DataFrame()
         for model in self.models:
-            (item_metrics, identifiers_columns) = model.evaluate(
-                self.evaluation_train_list_dataset, self.full_list_dataset
-            )
+            (item_metrics, identifiers_columns) = model.evaluate(self.evaluation_train_list_dataset, self.full_list_dataset)
             metrics_df = metrics_df.append(item_metrics)
         metrics_df[METRICS_DATASET.SESSION] = self.session_name
         self.metrics_df = self._reorder_metrics_df(metrics_df)
@@ -172,22 +160,20 @@ class TrainingSession:
         """Evaluate all the selected models, get the metrics dataframe and create the forecasts dataframe. """
         metrics_df = pd.DataFrame()
         for model in self.models:
-            (item_metrics, identifiers_columns, forecasts_df) = model.evaluate(
-                self.evaluation_train_list_dataset, self.full_list_dataset, make_forecasts=True
-            )
+            (item_metrics, identifiers_columns, forecasts_df) = model.evaluate(self.evaluation_train_list_dataset, self.full_list_dataset, make_forecasts=True)
             forecasts_df = forecasts_df.rename(columns={"index": self.time_column_name})
             if self.forecasts_df.empty:
                 self.forecasts_df = forecasts_df
             else:
-                self.forecasts_df = self.forecasts_df.merge(
-                    forecasts_df, on=[self.time_column_name] + identifiers_columns
-                )
+                self.forecasts_df = self.forecasts_df.merge(forecasts_df, on=[self.time_column_name] + identifiers_columns)
             metrics_df = metrics_df.append(item_metrics)
         metrics_df[METRICS_DATASET.SESSION] = self.session_name
         self.metrics_df = self._reorder_metrics_df(metrics_df)
 
         self.evaluation_forecasts_df = self.training_df.merge(
-            self.forecasts_df, on=[self.time_column_name] + identifiers_columns, how="left",
+            self.forecasts_df,
+            on=[self.time_column_name] + identifiers_columns,
+            how="left",
         )
         # sort forecasts dataframe by timeseries identifiers (ascending) and time column (descending)
         self.evaluation_forecasts_df = self.evaluation_forecasts_df.sort_values(
@@ -244,9 +230,7 @@ class TrainingSession:
         """
         if len(self.target_columns_names) == 1 and len(self.timeseries_identifiers_names) == 0:
             evaluation_metrics_df = self.metrics_df.copy()
-            evaluation_metrics_df = evaluation_metrics_df[
-                evaluation_metrics_df[METRICS_DATASET.TARGET_COLUMN] == METRICS_DATASET.AGGREGATED_ROW
-            ]
+            evaluation_metrics_df = evaluation_metrics_df[evaluation_metrics_df[METRICS_DATASET.TARGET_COLUMN] == METRICS_DATASET.AGGREGATED_ROW]
             evaluation_metrics_df[METRICS_DATASET.TARGET_COLUMN] = self.target_columns_names[0]
             return evaluation_metrics_df
         else:
@@ -267,9 +251,7 @@ class TrainingSession:
     def _check_timeseries_identifiers_columns_types(self):
         """ Raises ValueError if a timeseries identifiers column is not numerical or string """
         for column_name in self.timeseries_identifiers_names:
-            if not is_numeric_dtype(self.training_df[column_name]) and not is_string_dtype(
-                self.training_df[column_name]
-            ):
+            if not is_numeric_dtype(self.training_df[column_name]) and not is_string_dtype(self.training_df[column_name]):
                 raise ValueError(f"Time series identifier '{column_name}' must be of string or numeric type")
 
     def _compute_optimal_num_batches_per_epoch(self):

--- a/python-lib/gluonts_forecasts/utils.py
+++ b/python-lib/gluonts_forecasts/utils.py
@@ -3,6 +3,7 @@ import numpy as np
 from functools import reduce
 import copy
 from constants import TIMESERIES_KEYS
+from gluonts_forecasts.timeseries_preparation import prepare_timeseries_dataframe
 
 
 def apply_filter_conditions(df, conditions):
@@ -54,63 +55,18 @@ def add_future_external_features(gluon_train_dataset, external_features_future_d
         feat_dynamic_real_columns_names = timeseries[TIMESERIES_KEYS.FEAT_DYNAMIC_REAL_COLUMNS_NAMES]
         time_column_name = timeseries[TIMESERIES_KEYS.TIME_COLUMN_NAME]
 
-        # sort and then check that the time column is valid
-        timeseries_external_features_future_df[time_column_name] = pd.to_datetime(
-            timeseries_external_features_future_df[time_column_name]
-        ).dt.tz_localize(tz=None)
-        timeseries_external_features_future_df = timeseries_external_features_future_df.sort_values(
-            by=time_column_name, ascending=True
-        )
-        assert_time_column_valid(
-            timeseries_external_features_future_df, time_column_name, frequency, start_date=start_date, periods=periods
-        )
-        if i == 0:
-            # set the start date and periods to check that the following timeseries are identical
-            start_date = timeseries_external_features_future_df[time_column_name].iloc[0]
-            periods = len(timeseries_external_features_future_df.index)
+        timeseries_external_features_future_df = prepare_timeseries_dataframe(timeseries_external_features_future_df, time_column_name, frequency)
 
         feat_dynamic_real_future = timeseries_external_features_future_df[feat_dynamic_real_columns_names].values.T
 
         if feat_dynamic_real_future.shape[1] != prediction_length:
-            raise ValueError(
-                f"Please provide {prediction_length} future values of external features, as this was the forecasting horizon used for training"
-            )
+            raise ValueError(f"Please provide {prediction_length} future values of external features, as this was the forecasting horizon used for training")
 
         feat_dynamic_real_appended = np.append(feat_dynamic_real_train, feat_dynamic_real_future, axis=1)
 
         gluon_dataset.list_data[i][TIMESERIES_KEYS.FEAT_DYNAMIC_REAL] = feat_dynamic_real_appended
 
     return gluon_dataset
-
-
-def assert_time_column_valid(dataframe, time_column_name, frequency, start_date=None, periods=None):
-    """Assert that the time column has the same values as the pandas.date_range generated with frequency and the first and last row of dataframe[time_column_name]
-    (or with start_date and periods if specified).
-
-    Args:
-        dataframe (DataFrame)
-        time_column_name (str)
-        frequency (str): Use as frequency of pandas.date_range.
-        start_date (pandas.Timestamp, optional): Use as start_date of pandas.date_range if specified. Defaults to None.
-        periods (int, optional): Use as periods of pandas.date_range if specified. Defaults to None.
-
-    Raises:
-        ValueError: If the time column doesn't have regular time intervals of the chosen frequency.
-    """
-    if start_date is None:
-        start_date = dataframe[time_column_name].iloc[0]
-    if periods:
-        date_range_values = pd.date_range(start=start_date, periods=periods, freq=frequency).values
-    else:
-        end_date = dataframe[time_column_name].iloc[-1]
-        date_range_values = pd.date_range(start=start_date, end=end_date, freq=frequency).values
-
-    if not np.array_equal(dataframe[time_column_name].values, date_range_values):
-        error_message = f"Time column '{time_column_name}' does not have regular intervals of frequency '{frequency}'. "
-        if frequency.endswith(("M", "Y")):
-            error_message += "For Month/Year frequency, dates must be at end of month/year e.g. '2020-12-31 00:00:00'. "
-        error_message += "Please use the Time Series Preparation plugin to resample your time column."
-        raise ValueError(error_message)
 
 
 def concat_timeseries_per_identifiers(all_timeseries):

--- a/tests/python/unit/test_gluonts_forecasts_utils.py
+++ b/tests/python/unit/test_gluonts_forecasts_utils.py
@@ -1,5 +1,6 @@
 from gluonts.dataset.common import ListDataset
-from gluonts_forecasts.utils import assert_time_column_valid, add_future_external_features
+from gluonts_forecasts.timeseries_preparation import assert_time_column_valid
+from gluonts_forecasts.utils import add_future_external_features
 from constants import TIMESERIES_KEYS
 import pandas as pd
 import numpy as np

--- a/tests/python/unit/test_timeseries_preparation.py
+++ b/tests/python/unit/test_timeseries_preparation.py
@@ -1,0 +1,55 @@
+from gluonts_forecasts.timeseries_preparation import TimeseriesPreparator
+import pandas as pd
+
+
+def test_hour_truncation():
+    df = pd.DataFrame(
+        {
+            "date": [
+                "2020-01-07 12:12:00",
+                "2020-01-07 17:35:00",
+                "2020-01-07 14:55:00",
+                "2020-01-07 18:06:00",
+                "2020-01-08 04:40:00",
+                "2020-01-08 06:13:00",
+                "2020-01-08 03:23:00",
+            ],
+            "id": [1, 1, 1, 1, 2, 2, 2],
+        }
+    )
+    frequency = "2H"
+    time_column_name = "date"
+    timeseries_identifiers_names = ["id"]
+    df[time_column_name] = pd.to_datetime(df[time_column_name]).dt.tz_localize(tz=None)
+    preparator = TimeseriesPreparator(time_column_name, frequency, timeseries_identifiers_names)
+    dataframe_prepared = preparator.truncate_timestamps(df)
+    dataframe_prepared = preparator.sort(dataframe_prepared)
+    preparator.check_regular_frequency(dataframe_prepared)
+    dataframe_prepared = preparator.keep_last_timestamps(dataframe_prepared, 2)
+    assert dataframe_prepared[time_column_name][0] == pd.Timestamp("2020-01-07 16:00:00")
+    assert dataframe_prepared[time_column_name][3] == pd.Timestamp("2020-01-08 06:00:00")
+
+
+def test_week_sunday_truncation():
+    df = pd.DataFrame(
+        {
+            "date": [
+                "2021-01-01 12:12:00",
+                "2021-01-05 17:35:00",
+                "2021-01-15 14:55:00",
+            ],
+            "id": [1, 1, 1],
+        }
+    )
+    frequency = "W-SUN"
+    time_column_name = "date"
+    timeseries_identifiers_names = ["id"]
+    df[time_column_name] = pd.to_datetime(df[time_column_name]).dt.tz_localize(tz=None)
+    preparator = TimeseriesPreparator(time_column_name, frequency, timeseries_identifiers_names)
+    dataframe_prepared = preparator.truncate_timestamps(df)
+    dataframe_prepared = preparator.sort(dataframe_prepared)
+    preparator.check_regular_frequency(dataframe_prepared)
+
+    dataframe_prepared = preparator.keep_last_timestamps(dataframe_prepared, 2)
+    assert dataframe_prepared[time_column_name][0] == pd.Timestamp("2021-01-10")
+    assert dataframe_prepared[time_column_name][1] == pd.Timestamp("2021-01-17")

--- a/tests/python/unit/test_trained_model.py
+++ b/tests/python/unit/test_trained_model.py
@@ -54,9 +54,9 @@ class TestTrainedModel:
             "is_holiday",
             "is_weekend",
             "sales",
-            "forecast_percentile_10_sales",
-            "forecast_median_sales",
-            "forecast_percentile_90_sales",
+            "forecast_lower_sales",
+            "forecast_sales",
+            "forecast_upper_sales",
             METRICS_DATASET.SESSION,
             METRICS_DATASET.MODEL_COLUMN,
         ]
@@ -66,4 +66,4 @@ class TestTrainedModel:
         history_df = forecasts_df[forecasts_df["item"] == 2].iloc[2:]
 
         assert future_df["sales"].count() == 0 and history_df["sales"].count() == 4
-        assert future_df["forecast_median_sales"].count() == 2 and history_df["forecast_median_sales"].count() == 0
+        assert future_df["forecast_sales"].count() == 2 and history_df["forecast_sales"].count() == 0

--- a/tests/python/unit/test_training_session.py
+++ b/tests/python/unit/test_training_session.py
@@ -28,6 +28,7 @@ class TestTrainingSession:
                 "is_weekend": [1, 0, 0, 1, 0, 0],
             }
         )
+        self.df["date"] = pd.to_datetime(self.df["date"]).dt.tz_localize(tz=None)
         self.models_parameters = {
             "deepar": {"activated": True, "kwargs": {"dropout_rate": "0.3", "cell_type": "gru"}},
             "mqcnn": {"activated": True, "kwargs": {}},


### PR DESCRIPTION
PR with new module TimeseriesPreparator to:
- truncate timestamp (using same kind of truncation as gluonTS [here](https://github.com/awslabs/gluon-ts/blob/7187e25eda1380d8665f83f6d4c15ec78b8c745c/src/gluonts/dataset/common.py#L268))
- check for duplicate
- check for regular time intervals
- sort timeseries
- keep only the X last timestamps of each timeseries if specified by users
 
