### PR TITLE
Removing context_length from Training options

### DIFF
--- a/custom-recipes/timeseries-forecast-1-train-evaluate/recipe.json
+++ b/custom-recipes/timeseries-forecast-1-train-evaluate/recipe.json
@@ -374,16 +374,6 @@
             "visibilityCondition": "['choose_algorithms', 'customize_algorithms'].includes(model.forecasting_style)"
         },
         {
-            "name": "context_length",
-            "label": "Context length",
-            "type": "INT",
-            "description": "Number of input lags. If -1, same as forecasting horizon. Higher values increase runtime.",
-            "defaultValue": -1,
-            "mandatory": false,
-            "minI": -1,
-            "visibilityCondition": "['choose_algorithms', 'customize_algorithms'].includes(model.forecasting_style)"
-        },
-        {
             "name": "epoch",
             "label": "Number of epochs",
             "description": "Higher values increase performance but increase runtime linearly",

--- a/custom-recipes/timeseries-forecast-1-train-evaluate/recipe.py
+++ b/custom-recipes/timeseries-forecast-1-train-evaluate/recipe.py
@@ -35,7 +35,6 @@ training_session = TrainingSession(
     batch_size=params["batch_size"],
     user_num_batches_per_epoch=params["num_batches_per_epoch"],
     gpu=params["gpu"],
-    context_length=params["context_length"],
 )
 training_session.init(partition_root=params["partition_root"], session_name=session_name)
 

--- a/python-lib/dku_io_utils/recipe_config_loading.py
+++ b/python-lib/dku_io_utils/recipe_config_loading.py
@@ -93,12 +93,6 @@ def load_training_config(recipe_config):
     if not params["prediction_length"]:
         raise PluginParamValidationError("Please specify forecasting horizon")
 
-    params["context_length"] = recipe_config.get("context_length", -1)
-    if params["context_length"] < 0:
-        params["context_length"] = params["prediction_length"]
-    if params["context_length"] == 0:
-        raise PluginParamValidationError("Context length cannot be 0")
-
     params["forecasting_style"] = recipe_config.get("forecasting_style", "auto")
     params["epoch"] = recipe_config.get("epoch", 10)
     params["batch_size"] = recipe_config.get("batch_size", 32)
@@ -114,12 +108,10 @@ def load_training_config(recipe_config):
 
     # Overwrite values in case of autoML mode selected
     if params["forecasting_style"] == "auto":
-        params["context_length"] = params["prediction_length"]
         params["epoch"] = 10
         params["batch_size"] = 32
         params["num_batches_per_epoch"] = 50
     elif params["forecasting_style"] == "auto_performance":
-        params["context_length"] = params["prediction_length"]
         params["epoch"] = 30
         params["batch_size"] = 32
         params["num_batches_per_epoch"] = -1

--- a/python-lib/gluonts_forecasts/model.py
+++ b/python-lib/gluonts_forecasts/model.py
@@ -29,7 +29,6 @@ class Model(ModelHandler):
         use_external_features (bool)
         batch_size (int): Size of batch used by the GluonTS Trainer class
         gpu (str): Not implemented
-        context_length (int): Number of time steps used by model to make predictions
     """
 
     def __init__(
@@ -43,14 +42,12 @@ class Model(ModelHandler):
         batch_size=None,
         num_batches_per_epoch=None,
         gpu=None,
-        context_length=None,
     ):
         super().__init__(model_name)
         self.model_name = model_name
         self.model_parameters = model_parameters
         self.frequency = frequency
         self.prediction_length = prediction_length
-        self.context_length = context_length
         self.epoch = epoch
         self.use_external_features = use_external_features
         self.using_external_features = False
@@ -71,8 +68,6 @@ class Model(ModelHandler):
         if ModelHandler.can_use_external_feature(self) and self.use_external_features:
             self.using_external_features = True
             estimator_kwargs.update({"use_feat_dynamic_real": True})
-        if self.context_length is not None and ModelHandler.can_use_context_length(self):
-            estimator_kwargs.update({"context_length": self.context_length})
         self.estimator = ModelHandler.estimator(self, self.model_parameters, **estimator_kwargs)
         self.predictor = None
         self.evaluation_time = None
@@ -195,8 +190,6 @@ class Model(ModelHandler):
         if self.estimator is None:
             if ModelHandler.needs_num_samples(self):
                 kwargs.update({"num_samples": 100})
-            if self.context_length is not None and ModelHandler.can_use_context_length(self):
-                kwargs.update({"context_length": self.context_length})
             predictor = ModelHandler.predictor(self, **kwargs)
         else:
             try:
@@ -214,7 +207,6 @@ class Model(ModelHandler):
                 "model_name": ModelHandler.get_label(self),
                 "frequency": self.frequency,
                 "prediction_length": self.prediction_length,
-                "context_length": self.context_length,
                 "epoch": self.epoch,
                 "use_external_features": self.using_external_features,
                 "batch_size": self.batch_size,

--- a/python-lib/gluonts_forecasts/model_handler.py
+++ b/python-lib/gluonts_forecasts/model_handler.py
@@ -12,7 +12,6 @@ from gluonts.model.seasonal_naive import SeasonalNaivePredictor
 
 ESTIMATOR = "estimator"
 CAN_USE_EXTERNAL_FEATURES = "can_use_external_feature"
-CAN_USE_CONTEXT_LENGTH = "can_use_context_length"
 DEFAULT_KWARGS = "default_kwargs"
 TRAINER = "trainer"
 PREDICTOR = "predictor"
@@ -29,7 +28,6 @@ MODEL_DESCRIPTORS = {
         ESTIMATOR: None,
         PREDICTOR: IdentityPredictor,
         TRAINER: None,
-        CAN_USE_CONTEXT_LENGTH: False,
         NEEDS_NUM_SAMPLES: True,
         IS_NAIVE: True,
         DEFAULT_KWARGS: {
@@ -42,7 +40,6 @@ MODEL_DESCRIPTORS = {
         ESTIMATOR: None,
         PREDICTOR: MeanPredictor,
         TRAINER: None,
-        CAN_USE_CONTEXT_LENGTH: True,
         IS_NAIVE: True,
     },
     "seasonal_naive": {
@@ -51,7 +48,6 @@ MODEL_DESCRIPTORS = {
         ESTIMATOR: None,
         PREDICTOR: SeasonalNaivePredictor,
         TRAINER: None,
-        CAN_USE_CONTEXT_LENGTH: False,
         IS_NAIVE: True,
     },
     "simplefeedforward": {
@@ -111,7 +107,7 @@ class ModelHandler:
     def _get_model_descriptor(self):
         model_descriptor = MODEL_DESCRIPTORS.get(self.model_name)
         if model_descriptor is None:
-            return MODEL_DESCRIPTORS.get("naive")
+            return MODEL_DESCRIPTORS.get("seasonal_naive")
         else:
             return model_descriptor
 
@@ -144,9 +140,6 @@ class ModelHandler:
 
     def can_use_external_feature(self):
         return self.model_descriptor.get(CAN_USE_EXTERNAL_FEATURES, False)
-
-    def can_use_context_length(self):
-        return self.model_descriptor.get(CAN_USE_CONTEXT_LENGTH, True)
 
     def needs_num_samples(self):
         return self.model_descriptor.get(NEEDS_NUM_SAMPLES, False)

--- a/python-lib/gluonts_forecasts/model_handler.py
+++ b/python-lib/gluonts_forecasts/model_handler.py
@@ -91,7 +91,6 @@ MODEL_DESCRIPTORS = {
         ESTIMATOR: None,
         PREDICTOR: NPTSPredictor,
         TRAINER: None,
-        CAN_USE_CONTEXT_LENGTH: False,
     },
     "autoarima": {
         LABEL: "AutoARIMA",
@@ -99,7 +98,6 @@ MODEL_DESCRIPTORS = {
         ESTIMATOR: AutoARIMAEstimator,
         PREDICTOR: AutoARIMAPredictor,
         TRAINER: None,
-        CAN_USE_CONTEXT_LENGTH: False,
     },
 }
 

--- a/python-lib/gluonts_forecasts/training_session.py
+++ b/python-lib/gluonts_forecasts/training_session.py
@@ -26,7 +26,6 @@ class TrainingSession:
         batch_size (int): Size of batch used by the GluonTS Trainer class
         num_batches_per_epoch (int): Number of batches per epoch
         gpu (str): Not implemented
-        context_length (int): Number of time steps used by model to make predictions
     """
 
     def __init__(
@@ -44,7 +43,6 @@ class TrainingSession:
         batch_size=None,
         user_num_batches_per_epoch=None,
         gpu=None,
-        context_length=None,
     ):
         self.models_parameters = models_parameters
         self.models = None
@@ -71,7 +69,6 @@ class TrainingSession:
         self.user_num_batches_per_epoch = user_num_batches_per_epoch
         self.num_batches_per_epoch = None
         self.gpu = gpu
-        self.context_length = context_length
 
     def init(self, session_name, partition_root=None):
         """Create the session_path. Convert time column to pandas.Datetime without timezones.
@@ -112,7 +109,7 @@ class TrainingSession:
             target_columns_names=self.target_columns_names,
             timeseries_identifiers_names=self.timeseries_identifiers_names,
             external_features_columns_names=self.external_features_columns_names,
-            min_length=self.prediction_length + self.context_length,
+            min_length=2 * self.prediction_length,  # Assuming that context_length = prediction_length
         )
 
         gluon_list_datasets = gluon_dataset.create_list_datasets(cut_lengths=[self.prediction_length, 0])
@@ -140,7 +137,6 @@ class TrainingSession:
                     batch_size=self.batch_size,
                     num_batches_per_epoch=self.num_batches_per_epoch,
                     gpu=self.gpu,
-                    context_length=self.context_length,
                 )
             )
 
@@ -274,7 +270,7 @@ class TrainingSession:
 
     def _compute_optimal_num_batches_per_epoch(self):
         """ Compute the optimal value of num batches which garanties (statistically) full coverage of the dataset """
-        sample_length = self.prediction_length + self.context_length
+        sample_length = 2 * self.prediction_length  # Assuming that context_length = prediction_length
         sample_offset = max(sample_length // 10, 1)  # offset of 1 means that 2 samples can overlap on all but 1 timestep
         num_samples_total = 0
         for timeseries in self.evaluation_train_list_dataset.list_data:

--- a/tests/python/unit/test_model.py
+++ b/tests/python/unit/test_model.py
@@ -48,7 +48,6 @@ class TestModel:
             use_external_features=True,
             batch_size=32,
             num_batches_per_epoch=50,
-            context_length=self.prediction_length,
         )
         metrics, identifiers_columns, forecasts_df = model.evaluate(self.train_list_dataset, self.test_list_dataset, make_forecasts=True)
 
@@ -66,7 +65,6 @@ class TestModel:
             use_external_features=True,
             batch_size=32,
             num_batches_per_epoch=50,
-            context_length=self.prediction_length,
         )
         metrics, identifiers_columns, forecasts_df = model.evaluate(self.train_list_dataset, self.test_list_dataset, make_forecasts=True)
 
@@ -84,7 +82,6 @@ class TestModel:
             use_external_features=False,
             batch_size=32,
             num_batches_per_epoch=50,
-            context_length=self.prediction_length,
         )
         metrics, identifiers_columns, forecasts_df = model.evaluate(self.train_list_dataset, self.test_list_dataset, make_forecasts=True)
 
@@ -102,7 +99,6 @@ class TestModel:
             use_external_features=False,
             batch_size=32,
             num_batches_per_epoch=50,
-            context_length=self.prediction_length,
         )
         model.train(self.test_list_dataset)
         assert model.predictor is not None

--- a/tests/python/unit/test_training_session.py
+++ b/tests/python/unit/test_training_session.py
@@ -49,7 +49,6 @@ class TestTrainingSession:
             timeseries_identifiers_names=["store", "item"],
             batch_size=32,
             user_num_batches_per_epoch=-1,
-            context_length=1,
         )
         self.training_session.init(self.session_name)
         self.training_session.create_gluon_datasets()


### PR DESCRIPTION
The following tests rely on context_length to work:
    - _compute_optimal_num_batches_per_epoch
    - _check_minimum_length
The current approach is to assume context_length = prediction_length
