### PR TITLE
default trend='add' for ETSModel

### DIFF
--- a/python-lib/gluonts_forecasts/custom_models/seasonal_trend.py
+++ b/python-lib/gluonts_forecasts/custom_models/seasonal_trend.py
@@ -82,6 +82,15 @@ class SeasonalTrendEstimator(Estimator):
             raise ValueError("Keyword argument 'period' is not writable for SeasonalTrend, please use the Season length parameter")
         if "model" not in self.kwargs:
             self.kwargs["model"] = ETSModel
+
+        if self.kwargs["model"] == ETSModel:
+            # set trend='add' by default if no trend set by user in 'model_kwargs' for ETS
+            if "model_kwargs" not in self.kwargs:
+                self.kwargs["model_kwargs"] = {"trend": "add"}
+            elif "trend" not in self.kwargs["model_kwargs"]:
+                self.kwargs["model_kwargs"]["trend"] = "add"
+            logger.info(f"Setting trend parameter of ETSModel to: '{self.kwargs['model_kwargs']['trend']}'")
+
         if season_length < 2:
             raise ValueError("SeasonalTrend model must have a Season length higher than 2, please change the Season length parameter or unselect the model")
         self.season_length = season_length

--- a/python-lib/gluonts_forecasts/custom_models/utils.py
+++ b/python-lib/gluonts_forecasts/custom_models/utils.py
@@ -1,7 +1,11 @@
 def cast_kwargs(kwargs):
-    for arg in kwargs:
-        kwargs[arg] = cast_string(kwargs[arg])
-    return kwargs
+    kwargs_copy = kwargs.copy()
+    for arg, value in kwargs_copy.items():
+        if isinstance(value, dict):
+            kwargs_copy[arg] = cast_kwargs(value)
+        else:
+            kwargs_copy[arg] = cast_string(kwargs_copy[arg])
+    return kwargs_copy
 
 
 def cast_string(s):
@@ -9,6 +13,8 @@ def cast_string(s):
         return True
     elif s == "False":
         return False
+    elif s == "None":
+        return None
     elif is_int(s):
         return int(s)
     elif is_float(s):


### PR DESCRIPTION
When ETSModel is used, "trend"="add" is automatically set to "model_kwargs" unless user already set the "trend" parameter in the "model_kwargs".
However, I can't make "trend"="mul" work with ETSModel, I opened an issue here: https://github.com/statsmodels/statsmodels/issues/7309
I don't know if we should do something specific about that or let the default error happen (as it's really for advanced users).
 